### PR TITLE
hotfix: parsed_headline is empty

### DIFF
--- a/app/Eloquents/Entry.php
+++ b/app/Eloquents/Entry.php
@@ -46,4 +46,12 @@ class Entry extends Model
         }
         return collect($res);
     }
+
+    public function getParsedHeadlineAttribute() {
+        preg_match('/【(.*)】(.*)/', $this->headline, $headline);
+        return collect([
+            'title' => $headline[1],
+            'headline' => $headline[2],
+        ]);
+    }
 }

--- a/app/Eloquents/EntryDetail.php
+++ b/app/Eloquents/EntryDetail.php
@@ -19,14 +19,6 @@ class EntryDetail extends Model
         'xml_document',
     ];
 
-    public function getParsedHeadlineAttribute() {
-        preg_match('/【(.*)】(.*)/', $this->headline, $headline);
-        return collect([
-            'title' => $headline[1],
-            'headline' => $headline[2],
-        ]);
-    }
-
     public function entry() {
         return $this->belongsTo('App\Eloquents\Entry');
     }


### PR DESCRIPTION
parsed_headlineがemptyになる現象を修正しました